### PR TITLE
ReCreateOwnCertificateOnTimeInvalid to recreate certificate if the time is invalid (certificate only valid in future or past)

### DIFF
--- a/etc/ualds.conf
+++ b/etc/ualds.conf
@@ -68,6 +68,11 @@ MaxAgeRejectedCertificates = 1
 # If this is 'yes' then the certificate will be automatically re-created if the machine name has changed
 # Default behavior is "no".
 ReCreateOwnCertificateOnError = no
+# If this is 'yes' then the certificate will be automatically re-created if the time is invalid (certificate only valid in future or past)
+# Default behavior is "no".
+ReCreateOwnCertificateOnTimeInvalid = no
+# Minimum days the certificate must be valid for (Default=0)
+CertificateNotAfterOffset = 0
 
 [Log]
 # Log System: syslog (system log), file (custom log file)

--- a/etc/ualds.ini
+++ b/etc/ualds.ini
@@ -72,6 +72,11 @@ Win32StoreCheck = yes
 # If this is 'yes' then the certificate will be automatically re-created if the machine name has changed
 # Default behavior is "no".
 ReCreateOwnCertificateOnError = no
+# If this is 'yes' then the certificate will be automatically re-created if the time is invalid (certificate only valid in future or past)
+# Default behavior is "no".
+ReCreateOwnCertificateOnTimeInvalid = no
+# Minimum days the certificate must be valid for (Default=0)
+CertificateNotAfterOffset = 0
  
 [Log]
 # Log System: syslog (system log), file (custom log file)

--- a/stack/Stack/platforms/win32/opcua_p_openssl_pki.h
+++ b/stack/Stack/platforms/win32/opcua_p_openssl_pki.h
@@ -135,8 +135,9 @@ OpcUa_StatusCode OpcUa_P_OpenSSL_PKI_LoadPrivateKeyFromFile(
   @param pSubjectDNS           [out, optional] The subject's DNS name of the certificate.
   @param pCertThumbprint       [out, optional] The thumbprint of the certificate.
   @param pSubjectHash          [out, optional] The hash code of the certificate.
-  @param pCertRawLength        [out, optional] The length of the DER encoded data.
-                               can be smaller than the total length of pCertificate in case of chain certificate or garbage follow.
+  @param pCertRawLength        [out, optional] The length of the DER encoded data. Can be smaller than the total length of pCertificate in case of chain certificate or garbage follow.
+  @param pNotBefore            [out, optional] The the date on which a certificate becomes valid.
+  @param pNotAfter             [out, optional] The date in after which the certificate is no longer valid.
 */
 OpcUa_StatusCode OpcUa_P_OpenSSL_PKI_ExtractCertificateData(
     OpcUa_ByteString*           pCertificate,
@@ -147,7 +148,9 @@ OpcUa_StatusCode OpcUa_P_OpenSSL_PKI_ExtractCertificateData(
     OpcUa_ByteString*           pSubjectDNS,
     OpcUa_ByteString*           pCertThumbprint,
     OpcUa_UInt32*               pSubjectHash,
-    OpcUa_UInt32*               pCertRawLength);
+    OpcUa_UInt32*               pCertRawLength,
+    OpcUa_Int64*                a_pNotBefore,
+    OpcUa_Int64*                a_pNotAfter);
 
 /* NoSecurity functions */
 
@@ -254,8 +257,9 @@ OpcUa_StatusCode OpcUa_P_OpenSSL_PKI_NoSecurity_LoadPrivateKeyFromFile(
   @param pSubjectDNS           [out, optional] The subject's DNS name of the certificate.
   @param pCertThumbprint       [out, optional] The thumbprint of the certificate.
   @param pSubjectHash          [out, optional] The hash code of the certificate.
-  @param pCertRawLength        [out, optional] The length of the DER encoded data.
-                               can be smaller than the total length of pCertificate in case of chain certificate or garbage follow.
+  @param pCertRawLength        [out, optional] The length of the DER encoded data. Can be smaller than the total length of pCertificate in case of chain certificate or garbage follow.
+  @param pNotBefore            [out, optional] The the date on which a certificate becomes valid.
+  @param pNotAfter             [out, optional] The date in after which the certificate is no longer valid.
 */
 OpcUa_StatusCode OpcUa_P_OpenSSL_PKI_NoSecurity_ExtractCertificateData(
     OpcUa_ByteString*           pCertificate,
@@ -266,7 +270,9 @@ OpcUa_StatusCode OpcUa_P_OpenSSL_PKI_NoSecurity_ExtractCertificateData(
     OpcUa_ByteString*           pSubjectDNS,
     OpcUa_ByteString*           pCertThumbprint,
     OpcUa_UInt32*               pSubjectHash,
-    OpcUa_UInt32*               pCertRawLength);
+    OpcUa_UInt32*               pCertRawLength,
+    OpcUa_Int64*                pNotBefore,
+    OpcUa_Int64*                pNotAfter);
 
 OPCUA_END_EXTERN_C
 

--- a/stack/Stack/platforms/win32/opcua_p_openssl_pki_nosecurity.c
+++ b/stack/Stack/platforms/win32/opcua_p_openssl_pki_nosecurity.c
@@ -142,7 +142,9 @@ OpcUa_StatusCode OpcUa_P_OpenSSL_PKI_NoSecurity_ExtractCertificateData(
     OpcUa_ByteString*           a_pSubjectDNS,
     OpcUa_ByteString*           a_pCertThumbprint,
     OpcUa_UInt32*               a_pSubjectHash,
-    OpcUa_UInt32*               a_pCertRawLength)
+    OpcUa_UInt32*               a_pCertRawLength,
+    OpcUa_Int64*                a_pNotBefore,
+    OpcUa_Int64*                a_pNotAfter)
 {
     OpcUa_ReferenceParameter(a_pCertificate);
     OpcUa_ReferenceParameter(a_pIssuer);
@@ -153,6 +155,8 @@ OpcUa_StatusCode OpcUa_P_OpenSSL_PKI_NoSecurity_ExtractCertificateData(
     OpcUa_ReferenceParameter(a_pCertThumbprint);
     OpcUa_ReferenceParameter(a_pSubjectHash);
     OpcUa_ReferenceParameter(a_pCertRawLength);
+    OpcUa_ReferenceParameter(a_pNotBefore);
+    OpcUa_ReferenceParameter(a_pNotAfter);
 
     return OpcUa_BadNotSupported;
 }

--- a/stack/Stack/stackcore/opcua_pki.h
+++ b/stack/Stack/stackcore/opcua_pki.h
@@ -204,8 +204,9 @@ typedef OpcUa_StatusCode (OpcUa_PKIProvider_PfnLoadPrivateKeyFromFile)(
   @param pSubjectDNS           [out, optional] The subject's DNS name of the certificate.
   @param pCertThumbprint       [out, optional] The thumbprint of the certificate.
   @param pSubjectHash          [out, optional] The hash code of the certificate.
-  @param pCertRawLength        [out, optional] The length of the DER encoded data.
-                               can be smaller than the total length of pCertificate in case of chain certificate or garbage follow.
+  @param pCertRawLength        [out, optional] The length of the DER encoded data. Can be smaller than the total length of pCertificate in case of chain certificate or garbage follow.
+  @param pNotBefore            [out, optional] The the date on which a certificate becomes valid.
+  @param pNotAfter             [out, optional] The date in after which the certificate is no longer valid.
 */
 typedef OpcUa_StatusCode (OpcUa_PKIProvider_PfnExtractCertificateData)(
     OpcUa_ByteString*           pCertificate,
@@ -216,7 +217,9 @@ typedef OpcUa_StatusCode (OpcUa_PKIProvider_PfnExtractCertificateData)(
     OpcUa_ByteString*           pSubjectDNS,
     OpcUa_ByteString*           pCertThumbprint,
     OpcUa_UInt32*               pSubjectHash,
-    OpcUa_UInt32*               pCertRawLength);
+    OpcUa_UInt32*               pCertRawLength,
+    OpcUa_Int64*                pNotBefore,
+    OpcUa_Int64*                pNotAfter);
 
 /**
   @brief The PKI provider object.


### PR DESCRIPTION
The certificate of the LDS will be created for 3 years validity.  After this time it won't be renewed automatically. This causes the problem that some servers can't register anymore.

This PR proposes a solution:
- If the NotBefore lays in the future it will create a new cert from the current date onwards
- If the NotBefore lays in the past (with CertificateNotAfterOffset included) it will create a new cert from the current date onwards